### PR TITLE
tests: add tests for costs using CircuitCost

### DIFF
--- a/zk_prover/src/chips/range/tests.rs
+++ b/zk_prover/src/chips/range/tests.rs
@@ -292,4 +292,22 @@ mod testing {
             .render(9, &circuit, &root)
             .unwrap();
     }
+
+    #[cfg(feature = "dev-graph")]
+    #[test]
+    fn range_check_cost() {
+        use halo2_proofs::{dev::CircuitCost, halo2curves::bn256::G1};
+
+        // TODO: confirm the value of K
+        const K: u32 = 4;
+
+        let circuit = TestCircuit::<4> {
+            a: Fp::from(0x1f2f3f4f),
+            b: Fp::from(1),
+        };
+
+        let ckt_cost = CircuitCost::<G1, TestCircuit<4>>::measure(K, &circuit);
+        let proof_size = ckt_cost.proof_size(1);
+        print!("{:#?}", proof_size);
+    }
 }

--- a/zk_prover/src/circuits/tests.rs
+++ b/zk_prover/src/circuits/tests.rs
@@ -458,4 +458,27 @@ mod test {
             .render(K, &circuit, &root)
             .unwrap();
     }
+
+
+    #[cfg(feature = "dev-graph")]
+    #[test]
+    fn mst_inclusion_cost() {
+        use halo2_proofs::{dev::CircuitCost, halo2curves::bn256::G1};
+
+        // TODO: confirm the value of K
+        const K: u32 = 11;
+
+        let merkle_sum_tree =
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
+        let user_index = 0;
+        let merkle_proof = merkle_sum_tree.generate_proof(user_index).unwrap();
+        let circuit = MstInclusionCircuit::<LEVELS, N_CURRENCIES, N_BYTES>::init(merkle_proof);
+
+        let ckt_cost =
+            CircuitCost::<G1, MstInclusionCircuit<LEVELS, N_CURRENCIES, N_BYTES>>::measure(
+                K, &circuit,
+            );
+        let proof_size = ckt_cost.proof_size(1);
+        print!("{:#?}", proof_size);
+    }
 }


### PR DESCRIPTION
# Description

- Uses [CircuitCost](https://github.com/summa-dev/halo2/blob/8386d6e64fc33baccf626869123185890b8284dc/halo2_proofs/src/dev/cost.rs#L26) to generate cost reports for Range Check and MST Inclusion circuits
- Used [bn256::G1](https://github.com/privacy-scaling-explorations/halo2curves/blob/9fff22c5f72cc54fac1ef3a844e1072b08cfecdf/src/bn256/curve.rs#L33) as PrimeGroup for CircuitCost
- Used `K = 4` for Range Check and `K = 11` for MST Inclusion
    - Not entirely sure what those values mean. But reached those numbers after trial and error on getting `NotEnoughRowsAvailable` errors
    - Feel free to comment and help learn the usage & meaning of those values
- Not entirely sure how to interpret the output of the `CircuitCost::proof_size()` API either. Appreciate anyone who wants to help in on that
- [cost_model](https://github.com/zcash/halo2/blob/81729eca91ba4755e247f49c3a72a4232864ec9e/halo2_proofs/examples/cost-model.rs#L298) seems to give a more intuitive report on proof size and verification time. 
    - It already seems to be [adapted](https://github.com/privacy-scaling-explorations/halo2/blob/fa708ecafc53f4019ac0a6c2b9623573a98696de/halo2_proofs/examples/proof-size.rs#L91) for PSE's fork. But Summa seem to use their own [fork](https://github.com/zBlock-2/summa-solvency-schneier/blob/95d63fe1a55935542810138aa5d8de7f50f4e94b/zk_prover/Cargo.toml#L13) of halo2. So it needs to update with PSE's upstream before able to use it
    - Couldn't find a lot of diff bw [PSE's fork](https://github.com/privacy-scaling-explorations/halo2/blob/fa708ecafc53f4019ac0a6c2b9623573a98696de/halo2_frontend/src/dev/cost.rs#L1) and [zcash](https://github.com/zcash/halo2/blob/81729eca91ba4755e247f49c3a72a4232864ec9e/halo2_proofs/examples/cost-model.rs#L1) for [cost.rs](https://www.diffchecker.com/JDTWAId8/) though


Range Check:
```
ProofSize {
    instance: ProofContribution {
        commitments: 0,
        evaluations: 0,
    },
    advice: ProofContribution {
        commitments: 4,
        evaluations: 5,
    },
    fixed: ProofContribution {
        commitments: 0,
        evaluations: 4,
    },
    lookups: ProofContribution {
        commitments: 3,
        evaluations: 5,
    },
    equality: ProofContribution {
        commitments: 2,
        evaluations: 10,
    },
    vanishing: ProofContribution {
        commitments: 5,
        evaluations: 1,
    },
    multiopen: ProofContribution {
        commitments: 1,
        evaluations: 4,
    },
    polycomm: ProofContribution {
        commitments: 9,
        evaluations: 2,
    },
    _marker: PhantomData<halo2curves::bn256::curve::G1>,
}
```

MST Inclusion:
```
ProofSize {
    instance: ProofContribution {
        commitments: 0,
        evaluations: 1,
    },
    advice: ProofContribution {
        commitments: 3,
        evaluations: 7,
    },
    fixed: ProofContribution {
        commitments: 0,
        evaluations: 11,
    },
    lookups: ProofContribution {
        commitments: 3,
        evaluations: 5,
    },
    equality: ProofContribution {
        commitments: 2,
        evaluations: 11,
    },
    vanishing: ProofContribution {
        commitments: 6,
        evaluations: 1,
    },
    multiopen: ProofContribution {
        commitments: 1,
        evaluations: 5,
    },
    polycomm: ProofContribution {
        commitments: 23,
        evaluations: 2,
    },
    _marker: PhantomData<halo2curves::bn256::curve::G1>,
}
```